### PR TITLE
 Add GMail Style with UTF-8 Characters (fixes issues with dark themes). 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,3 +27,4 @@ Changelog
 * v0.6 -- Bug fix release (#7: PLI shows wrong indicators in Thunderbird 24)
 * v0.7 -- New Feature: Indicator style is now configurable. Besides the "Gmail style" there also the "triple style", which shows a single arrow (›) if a message is sent only to you, a double arrow (») if it is sent to a group and a triple arrow if it is sent to a mailing list.
 * v0.8 -- More robustness, addon will now notice changes in indentities and does not require a restart anymore. Also the default settings are properly initialized when the plugin is installed.
+* v0.9 -- New "GMail Style with UTF-8 Characters" adapts to font style, thus fixes issues with dark themes.

--- a/chrome/content/options.xul
+++ b/chrome/content/options.xul
@@ -2,17 +2,17 @@
 <!--
  * Personal Level Indicator Plugin for Thunderbird
  * Copyright (C) 2013 Tammo van Lessen
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -23,6 +23,7 @@
     <setting pref="personallevelindicator.mode" type="radio" title="Presentation Mode">
       <radiogroup>
         <radio value="gmail" label="GMail Style"/>
+        <radio value="gmailchars" label="GMail Style with UTF-8 Characters"/>
         <radio value="triple" label="Triple Style"/>
       </radiogroup>
     </setting>

--- a/chrome/content/pli_column_overlay.js
+++ b/chrome/content/pli_column_overlay.js
@@ -1,17 +1,17 @@
 /*
  * Personal Level Indicator Plugin for Thunderbird
  * Copyright (C) 2011  Tammo van Lessen
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -23,6 +23,7 @@ var PLIOverlay = {
     PLI_NOT_SET: 0,
     PLI_ONLY: 1,
     PLI_GROUP: 2,
+    PLI_CHAR_MODE: "gmailchars",
 
     init: function () {
         this.initialized = true;
@@ -121,24 +122,41 @@ var PLIOverlay = {
             return this.PLI_NOT_SET;
         }
     },
-    
+
 
     // nsIMsgCustomColumnHandler methods
     getCellProperties: function (row, col) {
-        let pli = this.calcPLI(this.getHeaderForRow(row));
-        if (pli == this.PLI_NOT_SET) {
-            return "pliNotSet-" + this.mode;
-        } else if (pli == this.PLI_ONLY) {
-            return "pliOnly-" + this.mode;
-        } else if (pli == this.PLI_GROUP) {
-            return "pliGroup-" + this.mode;
+        if (this.mode == this.PLI_CHAR_MODE) {
+          return "pliChars";
         } else {
-            return "";
+            let pli = this.calcPLI(this.getHeaderForRow(row));
+            if (pli == this.PLI_NOT_SET) {
+                return "pliNotSet-" + this.mode;
+            } else if (pli == this.PLI_ONLY) {
+                return "pliOnly-" + this.mode;
+            } else if (pli == this.PLI_GROUP) {
+                return "pliGroup-" + this.mode;
+            } else {
+                return "";
+            }
         }
     },
     getRowProperties: function (row) { return ""; },
-    getImageSrc: function (row, col) {},
-    getCellText: function (row, col) {},
+    getImageSrc: function (row, col) { },
+    getCellText: function (row, col) {
+        if (this.mode == this.PLI_CHAR_MODE) {
+            let pli = this.calcPLI(this.getHeaderForRow(row));
+            if (pli == this.PLI_NOT_SET) {
+                return "";
+            } else if (pli == this.PLI_ONLY) {
+                return "»";
+            } else if (pli == this.PLI_GROUP) {
+                return "›";
+            } else {
+                return "-";
+            }
+        }
+    },
     getSortStringForRow: function (hdr) {},
     getSortLongForRow: function (hdr) { return this.calcPLI(hdr); },
     isString: function () { return false; }

--- a/chrome/skin/pli_column_overlay.css
+++ b/chrome/skin/pli_column_overlay.css
@@ -1,22 +1,22 @@
 /*
  * Personal Level Indicator Plugin for Thunderbird
  * Copyright (C) 2011  Tammo van Lessen
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
- 
+
  #PLICol, treechildren::-moz-tree-image(PLICol)
  {list-style-image: url("chrome://pli.taval.de/skin/pli.png") !important;}
 
@@ -27,6 +27,8 @@
   width: 12px;
   max-width: 12px;}
 
+treechildren::-moz-tree-image(PLICol, pliChars)
+ {list-style-image: none !important;}
 treechildren::-moz-tree-image(PLICol, pliNotSet-gmail)
  {-moz-image-region: rect(0px 83px 16px 72px);}
 treechildren::-moz-tree-image(PLICol, pliOnly-gmail)

--- a/defaults/preferences/defaults.js
+++ b/defaults/preferences/defaults.js
@@ -1,20 +1,20 @@
 /*
  * Personal Level Indicator Plugin for Thunderbird
  * Copyright (C) 2013 Tammo van Lessen
- * 
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 
-pref("personallevelindicator.mode", "gmail");
+pref("personallevelindicator.mode", "gmailchars");

--- a/install.rdf
+++ b/install.rdf
@@ -5,7 +5,7 @@
   <Description about="urn:mozilla:install-manifest">
     <em:id>personal-level-indicators@taval.de</em:id>
     <em:name>Personal Level Indicators</em:name>
-    <em:version>0.9</em:version>
+    <em:version>0.10</em:version>
     <em:description>Shows an indicator so you can tell if an email was addressed only to you (&#xbb;), a group (&#x203a;), or a mailing list.</em:description>
     <em:creator>Tammo van Lessen</em:creator>
     <em:contributor>Piotr Orzechowski</em:contributor>
@@ -14,8 +14,8 @@
     <em:type>2</em:type>
     <em:optionsURL>chrome://pli.taval.de/content/options.xul</em:optionsURL>
     <em:optionsType>2</em:optionsType>
-    <!-- Target Application this theme can install into, 
-        with minimum and maximum supported versions. --> 
+    <!-- Target Application this theme can install into,
+        with minimum and maximum supported versions. -->
     <!-- Thunderbird -->
 	<em:targetApplication>
       <Description>

--- a/install.rdf
+++ b/install.rdf
@@ -8,6 +8,7 @@
     <em:version>0.9</em:version>
     <em:description>Shows an indicator so you can tell if an email was addressed only to you (&#xbb;), a group (&#x203a;), or a mailing list.</em:description>
     <em:creator>Tammo van Lessen</em:creator>
+    <em:contributor>Piotr Orzechowski</em:contributor>
     <em:homepageURL>https://github.com/vanto/tb-personal-level-indicator</em:homepageURL>
     <em:iconURL>chrome://pli.taval.de/skin/icon.png</em:iconURL>
     <em:type>2</em:type>


### PR DESCRIPTION
I have added a UTF-8 character based style.

Using characters instead of images has the advantage that the symbol adapts its style to the text style of the row.
That means text color (tagged mails, different/dark theme, ...) and text style (bold for unread mails) automatically fit the overall style:

![gmail style with utf-8 characters](https://user-images.githubusercontent.com/5220714/37836539-f8ffa35c-2eb2-11e8-8f55-2f2dfbaf4b2a.png)

Fixes #9 